### PR TITLE
Use buttons for auth navigation actions

### DIFF
--- a/app/src/main/java/com/example/dietlens/feature/forgot_password/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/example/dietlens/feature/forgot_password/ForgotPasswordScreen.kt
@@ -1,10 +1,10 @@
 package com.example.dietlens.feature.forgot_password
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Email
@@ -155,12 +155,22 @@ fun ForgotPasswordScreen(
             }
 
             Spacer(Modifier.height(16.dp))
-            Text(
-                stringResource(R.string.back_to_login),
-                color = Buttons,
-                fontSize = 12.sp,
-                modifier = Modifier.clickable { onBack() }
-            )
+            TextButton(
+                onClick = onBack,
+                colors = ButtonDefaults.textButtonColors(contentColor = Buttons)
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                    contentDescription = null,
+                    tint = Buttons
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    stringResource(R.string.back_to_login),
+                    fontSize = 12.sp,
+                    fontFamily = MontserratMedium
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/dietlens/feature/signin/presentation/LoginScreen.kt
+++ b/app/src/main/java/com/example/dietlens/feature/signin/presentation/LoginScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -219,21 +220,33 @@ fun LoginScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.height(23.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
-            Row {
+            Text(
+                stringResource(R.string.login_new_member),
+                fontSize = 14.sp,
+                fontFamily = MontserratMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = onRegisterClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                shape = RoundedCornerShape(8.dp),
+                border = BorderStroke(1.dp, Buttons),
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = Buttons)
+            ) {
                 Text(
-                    stringResource(R.string.login_new_member),
-                    fontSize = 14.sp,
-                    fontFamily = MontserratMedium
+                    text = stringResource(R.string.login_create_account),
+                    fontSize = 16.sp,
+                    fontFamily = MontserratSemiBold
                 )
-                Spacer(modifier = Modifier.width(5.dp))
-                Text(
-                    text = stringResource(R.string.login_register_now),
-                    fontSize = 14.sp,
-                    color = Buttons,
-                    fontFamily = MontserratSemiBold,
-                    modifier = Modifier.clickable { onRegisterClick() }
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = Buttons
                 )
             }
 

--- a/app/src/main/java/com/example/dietlens/feature/signup/RegisterScreen.kt
+++ b/app/src/main/java/com/example/dietlens/feature/signup/RegisterScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Lock
@@ -20,6 +21,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -210,15 +212,25 @@ fun RegisterScreen(
             }
             Spacer(modifier = Modifier.height(23.dp))
 
-            Row {
-                Text("Already a member?", fontFamily = MontserratMedium, fontSize = 13.sp)
+            OutlinedButton(
+                onClick = onLoginClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(48.dp),
+                shape = RoundedCornerShape(10.dp),
+                border = BorderStroke(1.dp, Buttons),
+                colors = ButtonDefaults.outlinedButtonColors(contentColor = Buttons)
+            ) {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                    contentDescription = null,
+                    tint = Buttons
+                )
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
-                    text = "Log In",
-                    color = Buttons,
-                    fontSize = 13.sp,
+                    text = stringResource(R.string.back_to_login),
                     fontFamily = MontserratSemiBold,
-                    modifier = Modifier.clickable { onLoginClick() }
+                    fontSize = 16.sp
                 )
             }
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -23,6 +23,7 @@
     <string name="login_next">Войти</string>
     <string name="login_new_member">Новый пользователь?</string>
     <string name="login_register_now">Зарегистрируйтесь</string>
+    <string name="login_create_account">Создать аккаунт</string>
     <string name="login_email_error">Поле email не может быть пустым</string>
     <string name="login_password_error">Поле пароля не может быть пустым</string>
     <string name="login_password_email_error">Поля email и пароль не могут быть пустыми</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="login_next">Sign in</string>
     <string name="login_new_member">New member?</string>
     <string name="login_register_now">Register now</string>
+    <string name="login_create_account">Create account</string>
     <string name="login_email_error">Email field cannot be empty</string>
     <string name="login_password_error">Password field cannot be empty</string>
     <string name="login_password_email_error">Email and password fields cannot be empty</string>


### PR DESCRIPTION
### Motivation
- Improve consistency and UX on auth flows by replacing small clickable text links with visible buttons for navigation and back actions across auth screens.
- Ensure parity with Android-style affordances so actions like creating an account and returning to login are more discoverable and accessible in `LoginScreen`, `RegisterScreen` and `ForgotPasswordScreen`.

### Description
- Replace the register CTA on `LoginScreen` with an `OutlinedButton` using `R.string.login_create_account` and a right arrow icon.
- Replace the "Already a member? Log In" clickable text on `RegisterScreen` with an `OutlinedButton` that shows a left arrow and uses `R.string.back_to_login`.
- Replace the clickable back text in `ForgotPasswordScreen` with a `TextButton` that includes a left arrow icon.
- Add `login_create_account` string entries to `app/src/main/res/values/strings.xml` and `app/src/main/res/values-ru/strings.xml` and adjust imports accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970d40400bc832c826de8498d6d2e55)